### PR TITLE
feat(helm):monitoring-stack初期構成追加

### DIFF
--- a/helm/grpc-app/Chart.yaml
+++ b/helm/grpc-app/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: grpc-app
+description: A Helm chart for deploying grpc-app
+type: application
+version: 0.1.0
+appVersion: "latest"

--- a/helm/monitoring-stack/README.md
+++ b/helm/monitoring-stack/README.md
@@ -1,0 +1,13 @@
+# Monitoring Stack Helm Chart
+
+このディレクトリに「kube-prometheus-stack」のカスタム"values.yaml"を格納。
+https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack
+
+Prometheus, Grafana, Alertmanager, Node Exporter, Kube State Metrics をまとめて導入
+
+※事前準備
+
+```bash
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+kubectl create namespace monitoring

--- a/helm/monitoring-stack/values.yaml
+++ b/helm/monitoring-stack/values.yaml
@@ -1,0 +1,19 @@
+grafana:
+  enabled: true
+  service:
+    type: LoadBalancer
+    port: 3000
+  adminPassword: "admin"
+
+prometheus:
+  prometheusSpec:
+    serviceMonitorSelectorNilUsesHelmValues: false
+
+alertmanager:
+  enabled: true
+
+nodeExporter:
+  enabled: true
+
+kubeStateMetrics:
+  enabled: true


### PR DESCRIPTION
## 概要
Prometheus/Grafana等の監視スタックをHelmチャート化、helm/monitoring-stack/へ追加

## 変更内容
- Prometheusスタック用Helmチャート作成
- "values.yaml"初期バージョン作成
- "README.md"へ使用法記載

## 目的
- k8s-observability-app プロジェクトの監視基盤を Helm により管理
- 今後のEKSデプロイのための構成管理