### PR TITLE
feat(manifest):Namespace定義追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 このリポジトリはCloud NativeとObservabilityのスキル習得を目的に構成。
 以下の技術、ツールを取り入れていく予定。
 
-Go(gRPC)
-Kubernetes(EKS)
-Helm
-GitHub Actions(CI)
-ArgoCD(CD)
-Prometheus/Grafana
-Loki
-Tempo
+- Go(gRPC)
+- Kubernetes(EKS)
+- Helm
+- GitHub Actions(CI)
+- ArgoCD(CD)
+- Prometheus/Grafana
+- Loki
+- Tempo

--- a/manifests/namespace.yaml
+++ b/manifests/namespace.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: grpc-app
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd
+---


### PR DESCRIPTION
## 目的
EKSデプロイ時のNamespace分離のため、以下3つのNamespace定義を記述したマニフェストを作成。

- grpc-app:gRPCアプリ用
- monitoring:Prometheusスタック用
- argocd:ArgoCD用