### PR TITLE
feat(dashboard):Grafana dashboard用ConfigMapとダッシュボード雛形作成

### DIFF
--- a/docs/dashboards/grpc-server-dashboard.json
+++ b/docs/dashboards/grpc-server-dashboard.json
@@ -1,0 +1,9 @@
+{
+    "annotations":{
+        "list": []
+    },
+    "panels": [],
+    "schemaVersion": 37,
+    "title": "gRPC Server Overview",
+    "version": 1
+}

--- a/helm/monitoring-stack/values.yaml
+++ b/helm/monitoring-stack/values.yaml
@@ -5,6 +5,20 @@ grafana:
     port: 3000
   adminPassword: "admin"
 
+  dashboardProviders:
+    dashboardproviders.yaml:
+      apiVersion: 1
+      providers:
+        - name: 'custom'
+          orgId: 1
+          folder: 'Custom Dashboards'
+          type: file
+          options:
+            path: /var/lib/grafana/dashboards/custom
+
+  dashboardsConfigMaps:
+    custom: "grafana-dashboards"
+
 prometheus:
   prometheusSpec:
     serviceMonitorSelectorNilUsesHelmValues: false

--- a/manifests/grafana-dashboards.yaml
+++ b/manifests/grafana-dashboards.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  grpc-server-dashboard.json: |
+    {{ .Files.Get "docs/dashboards/grpc-server-dashboard.json" | indent 2 }}


### PR DESCRIPTION
## 目的
Grafanaのダッシュボード定義をConfigMap化、Helmからの管理を実装。

## 内容
- gRPCサーバ用のGrafanaダッシュボードのJSONを作成
- ConfigMapリソースを作成