### PR TITLE
feat(collector):k8slogs receiver経由でLoki転送するCollector構成を追加

### DIFF
--- a/manifests/otelcol-loki.yaml
+++ b/manifests/otelcol-loki.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otelcol-config
+  namespace: monitoring
+data:
+  config.yaml: |
+    receivers:
+      k8slogs:
+        include:
+          namespaces: ["grpc-app"]
+        operators:
+          - type: move
+            from: attributes.k8s.pod.name
+            to: resource.pod.name
+
+    exporters:
+      loki:
+        endpoint: http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push
+
+    service:
+      pipelines:
+        logs:
+          receivers: [k8slogs]
+          exporters: [loki]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otelcol
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: otelcol
+  template:
+    metadata:
+      labels:
+        app: otelcol
+    spec:
+      containers:
+        - name: otelcol
+          image: otel/opentelemetry-collector:0.101.0
+          args: ["--config=/etc/otelcol/config.yaml"]
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/otelcol
+      volumes:
+        - name: config-volume
+          configMap:
+            name: otelcol-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otelcol
+  namespace: monitoring
+spec:
+  selector:
+    app: otelcol
+  ports:
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318


### PR DESCRIPTION
## 概要
- OpenTelemetry CollectorをManifest形式で追加
- k8slogs receiverを使用しgrpc-appNamespaceのログを収集
- Loki Exporter経由でLokiにログ転送する構成を実装

## 実装内容
- manifests/otelcol-loki.yamlにConfigMap, Deployment, Serviceを定義
- ログはk8slogs receiver → Loki Exporter → Grafana可視化を想定