### PR TITLE
feat(hpa):grpc-appのCPU使用率に基づくオートスケーリング設定追加(HPA)

### DIFF
--- a/manifests/hpa-grpc-app.yaml
+++ b/manifests/hpa-grpc-app.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: grpc-app-hpa
+  namespace: grpc-app
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: grpc-app
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 60


### PR DESCRIPTION
## 概要
- grpc-app DeploymentにHorizontalPodAutoscaler(HPA)を追加
- CPU使用率を基にPodのスケールアップ/ダウンを提示

## 実装内容
- manifests/hpa-grpc-app.yamlを新規作成
- CPU使用率60%以上でスケールアウト、3Podまで自動拡張