### PR TITLE
feat(helm):monitoring-stackにOpenTelemetry Collector Helmテンプレートを追加

### DIFF
--- a/helm/monitoring-stack/templates/otelcol-configmap.yaml
+++ b/helm/monitoring-stack/templates/otelcol-configmap.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.otelcol.configmap }}
+  namespace: {{ .Release.Namespace }}
+data:
+  config.yaml: |
+    receivers:
+      k8slogs:
+        include:
+          namespaces: ["grpc-app"]
+        operators:
+          - type: move
+            from: attributes.k8s.pod.name
+            to: resource.pod.name
+
+    exporters:
+      loki:
+        endpoint: {{ .Values.otelcol.lokiEndpoint }}
+
+    service:
+      pipelines:
+        logs:
+          receivers: [k8slogs]
+          exporters: [loki]

--- a/helm/monitoring-stack/templates/otelcol-deployment.yaml
+++ b/helm/monitoring-stack/templates/otelcol-deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.otelcol.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Values.otelcol.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.otelcol.name }}
+    spec:
+      containers:
+        - name: otelcol
+          image: {{ .Values.otelcol.image }}
+          args: ["--config=/etc/otelcol/config.yaml"]
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otelcol
+      volumes:
+        - name: config
+          configMap:
+            name: {{ .Values.otelcol.configmap }}

--- a/helm/monitoring-stack/templates/otelcol-service.yaml
+++ b/helm/monitoring-stack/templates/otelcol-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.otelcol.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    app: {{ .Values.otelcol.name }}
+  ports:
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+  type: ClusterIP

--- a/helm/monitoring-stack/values.yaml
+++ b/helm/monitoring-stack/values.yaml
@@ -4,20 +4,16 @@ grafana:
     type: LoadBalancer
     port: 3000
   adminPassword: "admin"
-
   dashboardProviders:
     dashboardproviders.yaml:
       apiVersion: 1
       providers:
         - name: 'custom'
           orgId: 1
-          folder: 'Custom Dashboards'
+          folder: ''
           type: file
           options:
             path: /var/lib/grafana/dashboards/custom
-
-  dashboardsConfigMaps:
-    custom: "grafana-dashboards"
 
 prometheus:
   prometheusSpec:
@@ -31,3 +27,29 @@ nodeExporter:
 
 kubeStateMetrics:
   enabled: true
+
+tempo:
+  server:
+    extraArgs:
+      - --search.enabled=true
+  traces:
+    otlp:
+      enabled: true
+      http:
+        enabled: true
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 200m
+      memory: 256Mi
+  persistence:
+    enabled: false
+
+otelcol:
+  enabled: true
+  name: otelcol
+  image: otel/opentelemetry-collector:0.101.0
+  configmap: otelcol-config
+  lokiEndpoint: http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push


### PR DESCRIPTION
## 概要
- OpenTelemetry Collector(otelcol)をhelm/monitoring-stackチャートへ統合
- EKSデプロイを前提としてHelm管理
- Loki連携含むk8slogs receiverをConfigMapで管理
- 

## 実装内容 
- helm/monitoring-stack/templates/otelcol-*.yaml を作成
- values.yamlにotelcolセクションを追加
